### PR TITLE
remove duplicate definition: NIFTI_INTENT_VECTOR defined twice

### DIFF
--- a/R/convert_intent.R
+++ b/R/convert_intent.R
@@ -50,7 +50,6 @@ convert_intent = function(intent) {
 
     "NIFTI_INTENT_SYMMATRIX" = "symmatrix",
     "NIFTI_INTENT_DISPVECT" = "dispvect",
-    "NIFTI_INTENT_VECTOR" = "vector",
 
     "NIFTI_INTENT_QUATERNION" = "quads",
     "NIFTI_INTENT_DIMLESS" = "dimless"


### PR DESCRIPTION
NIFTI_INTENT_VECTOR is defined twice here. Does not hurt, but may confuse somebody.