### PR TITLE
Add `idx` argument to read_gifti

### DIFF
--- a/R/read_gifti.R
+++ b/R/read_gifti.R
@@ -2,6 +2,11 @@
 #' @description Reads a GIFTI File and parses the output
 #'
 #' @param file Name of file to read
+#' @param idx Numeric vector indicating the data indices to read. If \code{NULL}
+#'  (default), read all the data. Must be a subset of the indices present in the
+#'  file, or an error will occur. Indices that are not read in will be indicated
+#'  by empty entries in the output \code{"gifti"} object. Note that all metadata
+#'  will be read in regardless of \code{"idx"}.
 #'
 #' @return List of values
 #' @export
@@ -39,7 +44,7 @@
 #' }
 #' }
 #'
-readgii = function(file){
+readgii = function(file, idx=NULL){
 
   if (length(file) > 1) {
     res = lapply(file, readgii)
@@ -142,7 +147,10 @@ readgii = function(file){
   L = vector(mode = "list",
              length = N)
 
-  for (ind in seq(N)) {
+  if (is.null(idx)) { idx <- seq(N) } else { idx <- as.numeric(idx) }
+  stopifnot(all(idx %in% seq(N)))
+
+  for (ind in idx) {
 
     encoding = info$Encoding[ind]
     datatype = info$DataType[ind]
@@ -193,14 +201,14 @@ readgii = function(file){
 
 #' @rdname readgii
 #' @export
-readGIfTI = function(file){
-  res = readgii(file)
+readGIfTI = function(file, idx=NULL){
+  res = readgii(file, idx)
   return(res)
 }
 
 #' @rdname readgii
 #' @export
-read_gifti = function(file){
-  res = readgii(file)
+read_gifti = function(file, idx=NULL){
+  res = readgii(file, idx)
   return(res)
 }

--- a/man/readgii.Rd
+++ b/man/readgii.Rd
@@ -6,14 +6,20 @@
 \alias{read_gifti}
 \title{Read GIFTI File}
 \usage{
-readgii(file)
+readgii(file, idx = NULL)
 
-readGIfTI(file)
+readGIfTI(file, idx = NULL)
 
-read_gifti(file)
+read_gifti(file, idx = NULL)
 }
 \arguments{
 \item{file}{Name of file to read}
+
+\item{idx}{Numeric vector indicating the data indices to read. If \code{NULL}
+(default), read all the data. Must be a subset of the indices present in the
+file, or an error will occur. Indices that are not read in will be indicated
+by empty entries in the output \code{"gifti"} object. Note that all metadata
+will be read in regardless of \code{"idx"}.}
 }
 \value{
 List of values


### PR DESCRIPTION
Hello Dr. Muschelli!

Dr. Mejia and I want to enable users of `ciftiTools::read_cifti` to read only certain columns of a CIFTI file. This could be useful, for example, for reading only the first volumes of an fMRI scan that is 90k voxels x 1200 timepoints. This requires updating `read_gifti` to read only certain "columns" (entries in the xml list--is there a better word?) of a GIFTI file.

To enable this, I added an argument to `read_gifti` to select which data columns to read in. Do you think this additional argument is okay? If so, do you prefer to keep the data columns that are not read in as empty entries in the `gifti` output (as implemented here) or to remove those empty entries from the `gifti` output (which I can implement instead)?

BTW, I will need to edit `write_gifti` to reflect these new changes.