### PR TITLE
Replace `options()$digits` with `getOption("digits")`.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gifti
 Type: Package
 Title: Reads in 'Neuroimaging' 'GIFTI' Files with Geometry Information
-Version: 0.8.0
+Version: 0.8.1
 Date: 2021-03-31
 Author: John Muschelli
 Maintainer: John Muschelli <muschellij2@gmail.com>

--- a/R/data_encoder.R
+++ b/R/data_encoder.R
@@ -35,7 +35,7 @@ data_encoder = function(
 
   encoding = match.arg(encoding)
   if (encoding == "ASCII") {
-    dig_opt = options()$digits
+    dig_opt = getOption("digits")
     on.exit({
       options(digits = dig_opt)
     })


### PR DESCRIPTION
I was getting an error on a certain computer where `options()` yielded an error. 

> options()
Error in options() : 
  Value of SET_STRING_ELT() must be a 'CHARSXP' not a 'NULL'

This is avoided if only the `"digits"` option is obtained directly with `getOption`.