### PR TITLE
0.8.3: Avoid a warning about NA values; Patch reading CoordinateSystemTransformMatrix if multiple spaces are in MatrixData

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,9 +12,9 @@ jobs:
   R-CMD-check:
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: r-lib/actions/setup-pandoc@v1
-      - uses: r-lib/actions/setup-r@master
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2
       - name: Install dependencies
         run: |
           install.packages(c("remotes", "rcmdcheck"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,5 +26,5 @@ Suggests:
 BugReports: https://github.com/muschellij2/gifti/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gifti
 Type: Package
 Title: Reads in 'Neuroimaging' 'GIFTI' Files with Geometry Information
-Version: 0.8.2
+Version: 0.8.3
 Date: 2021-03-31
 Author: John Muschelli
 Maintainer: John Muschelli <muschellij2@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,5 +26,5 @@ Suggests:
 BugReports: https://github.com/muschellij2/gifti/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr

--- a/R/data_decoder.R
+++ b/R/data_decoder.R
@@ -61,7 +61,12 @@ data_decoder = function(
     values = values[ !values %in% "" ]
     values = trimws(values)
     values = strsplit(values, " ")
-    values = lapply(values, as.numeric)
+    as.numeric2 <- function(x, ...){
+      NAmask <- x=="NA"
+      x2 <- x; x2[NAmask] <- 0
+      ifelse(NAmask, NA, as.numeric(x2))
+    }
+    values = lapply(values, as.numeric2)
     values = unlist(values)
     return(values)
   }

--- a/R/read_gifti.R
+++ b/R/read_gifti.R
@@ -106,7 +106,6 @@ readgii = function(file){
         mat = trimws(mat)
         mat = mat[ !mat %in% ""]
         mat = lapply(strsplit(mat, "\\s+"), as.numeric)
-        mat = lapply(mat, function(q){q[!is.na(q)]})
         mat = do.call("rbind", mat)
         return(mat)
       })

--- a/R/read_gifti.R
+++ b/R/read_gifti.R
@@ -105,7 +105,7 @@ readgii = function(file){
         mat = strsplit(mat, "\n")[[1]]
         mat = trimws(mat)
         mat = mat[ !mat %in% ""]
-        mat = lapply(strsplit(mat, " "), as.numeric)
+        mat = lapply(strsplit(mat, "\\s+"), as.numeric)
         mat = lapply(mat, function(q){q[!is.na(q)]})
         mat = do.call("rbind", mat)
         return(mat)

--- a/R/read_gifti.R
+++ b/R/read_gifti.R
@@ -106,6 +106,7 @@ readgii = function(file){
         mat = trimws(mat)
         mat = mat[ !mat %in% ""]
         mat = lapply(strsplit(mat, " "), as.numeric)
+        mat = lapply(mat, function(q){q[!is.na(q)]})
         mat = do.call("rbind", mat)
         return(mat)
       })


### PR DESCRIPTION
The change in `data_decoder` converts "NA" to NA while avoiding the warning "NAs introduced by coercion 
".

The change in `readgii` handles the case where there are multiple spaces between the numbers in `MatrixData`.